### PR TITLE
fix guest null error

### DIFF
--- a/web-dev/src/components/HomePage/HomePageComponent.js
+++ b/web-dev/src/components/HomePage/HomePageComponent.js
@@ -19,8 +19,12 @@ const HomePageComponent = () => {
 
     // set bookmarks from the redux state
     const bookmarks = useSelector(state => state.bookmarks);
+
     // update bookmarks once the state changes
-    useEffect(() => findAllBookmarkedByUser(dispatch, currentUser.userID), [dispatch, currentUser.userID]);
+    useEffect(() => {
+        if (currentUser) { findAllBookmarkedByUser(dispatch, currentUser.userID) }
+        else { return bookmarks }
+    }, [dispatch]);
 
     // Retrieve a random sample of movies from the database only once
     useEffect(() => {


### PR DESCRIPTION
Passing as guest caused a null issue on the homepage since the get bookmark's function is only defined for users